### PR TITLE
Remove doc from published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic-extension/akashic-timeline",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "timeline library for akashic",
   "main": "lib/index.js",
   "scripts": {
@@ -14,8 +14,7 @@
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",
   "files": [
-    "lib",
-    "doc"
+    "lib"
   ],
   "devDependencies": {
     "@akashic/akashic-engine": "~1.10.1",


### PR DESCRIPTION
Typedoc の生成物が publish のファイルサイズの大半を占めていて無駄なので取り除きます。
