### PR TITLE
update typedoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased changes
+## 2.0.1
 
 * ドキュメントが生成できていなかったため修正
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased changes
+
+* ドキュメントが生成できていなかったため修正
+
 ## 2.0.0
 
 * akashic-engine@2.0.0 に追従。あわせてバージョンを 2.0.0 に。

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,7 @@ gulp.task("install:typings:src", shell.task("typings install"));
 
 gulp.task("install:typings:spec", shell.task("typings install", { cwd: "spec/" }));
 
-gulp.task("compile", shell.task("tsc"));
+gulp.task("compile", shell.task("tsc -p ./"));
 
 gulp.task("compile:spec",　["install:typings:spec"], shell.task("tsc", {cwd: "spec/"}));
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mdast": "~2.0.0",
     "mdast-lint": "~1.1.1",
     "tslint": "~3.7.4",
-    "typedoc": "~0.4.4",
+    "typedoc": "^0.11.1",
     "typescript": "~2.1.6",
     "typings": "^1.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic-extension/akashic-timeline",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "timeline library for akashic",
   "main": "lib/index.js",
   "scripts": {

--- a/spec/tsconfig.json
+++ b/spec/tsconfig.json
@@ -4,7 +4,8 @@
     "noLib": true,
     "noImplicitAny": true,
     "module": "commonjs",
-    "outDir": "./build"
+    "outDir": "./build",
+    "types": []
   },
   "filesGlob": [
     "../node_modules/typescript/lib/lib.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "noLib": true,
     "noImplicitAny": true,
     "outDir": "lib",
-    "module": "commonjs"
+    "module": "commonjs",
+    "types": []
   },
   "filesGlob": [
     "./node_modules/typescript/lib/lib.es6.d.ts",


### PR DESCRIPTION
### 概要
* ドキュメント生成スクリプトが動かなくなっていたので、動くように修正しました。

### やったこと
* ドキュメント生成スクリプトを動くようにするためにtypedocのバージョンを上げた
  * 動かない原因がtypedoc@0.4.4が依存しているtypescriptのバージョンが1.8で、typescript@2以降の書き方をしている場合にエラーを吐いてしまっていたため

* ビルド・テストスクリプト実行時にnode_modules/@types以下のファイルも見に行って落ちるようになったので、見に行かないようにするためにtsconfigに`types:[]`を指定