### PR TITLE
Change Tween#destroyed() -> Tween#isFinished()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.3.0
+* Tween#destroyed() を Tween#isFinished() へ Function 名を変更
+
 ## 2.2.0
 * Tweenオブジェクト生成時に `modified` と `destroyed` を省略した場合、対象オブジェクトのものを使うよう変更
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic-extension/akashic-timeline",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "timeline library for akashic",
   "main": "lib/index.js",
   "scripts": {

--- a/spec/src/TimelineSpec.ts
+++ b/spec/src/TimelineSpec.ts
@@ -100,7 +100,7 @@ describe("test Timeline", () => {
 		var tw = tl.create({x: 100, y: 200});
 		var firedFps = 0;
 		var firedCount = 0;
-		tw.destroyed = () => {
+		tw.isFinished = () => {
 			return false;
 		};
 		tw._fire = (fps) => {
@@ -121,13 +121,13 @@ describe("test Timeline", () => {
 		var tl = new Timeline(scene);
 		var tw1 = tl.create({x: 100, y: 200});
 		var tw1d = false;
-		tw1.destroyed = () => {
+		tw1.isFinished = () => {
 			return tw1d;
 		};
 		expect(tl._tweens.length).toBe(1);
 		var tw2 = tl.create({x: 300, y: 400});
 		var tw2d = false;
-		tw2.destroyed = () => {
+		tw2.isFinished = () => {
 			return tw2d;
 		};
 		expect(tl._tweens.length).toBe(2);

--- a/spec/src/TweenSpec.ts
+++ b/spec/src/TweenSpec.ts
@@ -453,13 +453,23 @@ describe("test Tween", () => {
 	it("isFinished", () => {
 		var target = {x: 0, y: 0};
 		var tw = new Tween(target);
+		// 生成直後は終了していない
+		var ret = tw.isFinished();
+		expect(ret).toBe(false);
 		tw._loop = false;
-		expect(tw.isFinished()).toBe(true);
+		expect(tw.isFinished()).toBe(false);
 		tw._loop = true;
 		expect(tw.isFinished()).toBe(false);
-		tw._loop = false;
-		tw.to({x: 200, y: 300}, 1000);
+		// アニメーション途中
+		tw.to({ x: 200, y: 300 }, 500);
+		tw._fire(300);
 		expect(tw.isFinished()).toBe(false);
+		// アニメーション完了 loop=true
+		tw._fire(200);
+		expect(tw.isFinished()).toBe(false);
+		// アニメーション完了 loop=false
+		tw._loop = false;
+		expect(tw.isFinished()).toBe(true);
 	});
 
 	it("isFinished - destroyedHandler", () => {

--- a/spec/src/TweenSpec.ts
+++ b/spec/src/TweenSpec.ts
@@ -453,9 +453,8 @@ describe("test Tween", () => {
 	it("isFinished", () => {
 		var target = {x: 0, y: 0};
 		var tw = new Tween(target);
-		// 生成直後は終了していない
-		var ret = tw.isFinished();
-		expect(ret).toBe(false);
+		// インスタンス生成直後は終了していない
+		expect(tw.isFinished()).toBe(false);
 		tw._loop = false;
 		expect(tw.isFinished()).toBe(false);
 		tw._loop = true;

--- a/spec/src/TweenSpec.ts
+++ b/spec/src/TweenSpec.ts
@@ -450,19 +450,19 @@ describe("test Tween", () => {
 		expect(tw._target).toEqual({scaleX: 4, scaleY: 4});
 	});
 
-	it("destroyed", () => {
+	it("isFinished", () => {
 		var target = {x: 0, y: 0};
 		var tw = new Tween(target);
 		tw._loop = false;
-		expect(tw.destroyed()).toBe(true);
+		expect(tw.isFinished()).toBe(true);
 		tw._loop = true;
-		expect(tw.destroyed()).toBe(false);
+		expect(tw.isFinished()).toBe(false);
 		tw._loop = false;
 		tw.to({x: 200, y: 300}, 1000);
-		expect(tw.destroyed()).toBe(false);
+		expect(tw.isFinished()).toBe(false);
 	});
 
-	it("destroyed - destroyedHandler", () => {
+	it("isFinished - destroyedHandler", () => {
 		var target = {x: 0, y: 0};
 		var dres = false;
 		var d = () => {
@@ -470,9 +470,9 @@ describe("test Tween", () => {
 		};
 		var tw = new Tween(target, {destroyed: d});
 		tw._loop = true;
-		expect(tw.destroyed()).toBe(false);
+		expect(tw.isFinished()).toBe(false);
 		dres = true;
-		expect(tw.destroyed()).toBe(true);
+		expect(tw.isFinished()).toBe(true);
 	});
 
 	it("push - no pararel", () => {
@@ -542,14 +542,14 @@ describe("test Tween", () => {
 		let count = 0;
 		const target = {x: 0, y: 0, destroyed: () => { count++; return false; }};
 		const tw = new Tween(target);
-		tw.destroyed();
+		tw.isFinished();
 		expect(count).toBe(1);
-		tw.destroyed();
+		tw.isFinished();
 		expect(count).toBe(2);
 		const twLoop = new Tween(target, {loop: true});
-		twLoop.destroyed();
+		twLoop.isFinished();
 		expect(count).toBe(3);
-		twLoop.destroyed();
+		twLoop.isFinished();
 		expect(count).toBe(4);
 	});
 });

--- a/src/Timeline.ts
+++ b/src/Timeline.ts
@@ -82,7 +82,7 @@ class Timeline {
 		var tmp: Tween[] = [];
 		for (var i = 0; i < this._tweens.length; ++i) {
 			var tween = this._tweens[i];
-			if (!tween.destroyed()) {
+			if (!tween.isFinished()) {
 				tween._fire(1000 / this._fps);
 				tmp.push(tween);
 			}

--- a/src/Tween.ts
+++ b/src/Tween.ts
@@ -306,10 +306,10 @@ class Tween {
 	}
 
 	/**
-	 * Tweenが破棄されたかどうかを返す。
+	 * アニメーションが終了しているかどうかを返す。
 	 * `_target`が破棄された場合又は、全アクションの実行が終了した場合に`true`を返す。
 	 */
-	destroyed(): boolean {
+	isFinished(): boolean {
 		var ret = false;
 		if (this._destroyedHandler) {
 			ret = this._destroyedHandler.call(this._target);
@@ -325,7 +325,7 @@ class Tween {
 	 * @param delta 前フレームからの経過時間
 	 */
 	_fire(delta: number): void {
-		if (this._steps.length === 0 || this.destroyed() || this.paused) {
+		if (this._steps.length === 0 || this.isFinished() || this.paused) {
 			return;
 		}
 		if (this._stepIndex >= this._steps.length) {

--- a/src/Tween.ts
+++ b/src/Tween.ts
@@ -315,7 +315,7 @@ class Tween {
 			ret = this._destroyedHandler.call(this._target);
 		}
 		if (!ret) {
-			ret = this._stepIndex >= this._steps.length && !this._loop;
+			ret = this._stepIndex !== 0 && this._stepIndex >= this._steps.length && !this._loop;
 		}
 		return ret;
 	}


### PR DESCRIPTION
## 修正内容

- Tween#destroyed() の実装が破棄されたかどうかとアニメーションが終了したかどうかを見ているので、関数名を `isFinished` へ変更。
-他ファイルにて、 `destroyed()` を使用していた箇所を `isFinished()` へ修正。
- Tweenの生成直後(アニメーションが実行されていない状態)に isFinished() が true を返す問題を修正
