### PR TITLE
keep Timeline#create() in call()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 3.2.0
+* `Tween#call()` の処理中に `timeline.create()` を実行して Tween を生成した場合、 Tween が Timeline キューに正しく追加されない不具合を修正
+
 ## 3.1.0
 * Easing#easeInOutBack(), easeOutBounce() を追加
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic-extension/akashic-timeline",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "timeline library for akashic",
   "main": "lib/index.js",
   "scripts": {

--- a/src/Timeline.ts
+++ b/src/Timeline.ts
@@ -63,6 +63,12 @@ export class Timeline {
 				tween.complete();
 			}
 		}
+		for (let i = 0; i < this._tweensCreateQue.length; ++i) {
+			const tween = this._tweensCreateQue[i];
+			if (!tween.isFinished()) {
+				tween.complete();
+			}
+		}
 	}
 
 	/**

--- a/src/Timeline.ts
+++ b/src/Timeline.ts
@@ -116,12 +116,12 @@ export class Timeline {
 	}
 
 	_handler(): void {
-		this._tweens = this._tweens.concat(this._tweensCreateQue);
-		this._tweensCreateQue = [];
-
-		if (this._tweens.length === 0 || this.paused) {
+		if (this.paused || this._tweens.length + this._tweensCreateQue.length === 0) {
 			return;
 		}
+
+		this._tweens = this._tweens.concat(this._tweensCreateQue);
+		this._tweensCreateQue = [];
 
 		const tmp: Tween[] = [];
 		for (let i = 0; i < this._tweens.length; ++i) {

--- a/src/Timeline.ts
+++ b/src/Timeline.ts
@@ -110,11 +110,18 @@ export class Timeline {
 		if (this._tweens.length === 0 || this.paused) {
 			return;
 		}
-		const tmp: Tween[] = [];
 		for (let i = 0; i < this._tweens.length; ++i) {
 			const tween = this._tweens[i];
 			if (!tween.isFinished()) {
 				tween._fire(1000 / this._fps);
+			}
+		}
+
+		// tween._fire() で発火した関数で _tweens が更新された場合、単一の for ループでは tmp に加えることができないため、ループを分離
+		const tmp: Tween[] = [];
+		for (let i = 0; i < this._tweens.length; ++i) {
+			const tween = this._tweens[i];
+			if (!tween.isFinished()) {
 				tmp.push(tween);
 			}
 		}

--- a/src/Timeline.ts
+++ b/src/Timeline.ts
@@ -26,7 +26,7 @@ export class Timeline {
 		this._tweensCreateQue = [];
 		this._fps = this._scene.game.fps;
 		this.paused = false;
-		scene.update.add(this._handler, this);
+		scene.onUpdate.add(this._handler, this);
 	}
 
 	/**
@@ -103,7 +103,7 @@ export class Timeline {
 	destroy(): void {
 		this.clear();
 		if (!this._scene.destroyed()) {
-			this._scene.update.remove(this._handler, this);
+			this._scene.onUpdate.remove(this._handler, this);
 		}
 		this._scene = undefined;
 	}

--- a/src/Timeline.ts
+++ b/src/Timeline.ts
@@ -120,7 +120,7 @@ export class Timeline {
 		const tmp: Tween[] = [];
 		for (let i = 0; i < this._tweens.length; ++i) {
 			const tween = this._tweens[i];
-			if (!tween.isFinished()) {
+			if (!tween.shouldRemove()) {
 				tween._fire(1000 / this._fps);
 				tmp.push(tween);
 			}

--- a/src/Tween.ts
+++ b/src/Tween.ts
@@ -33,6 +33,12 @@ export class Tween {
 	_target: any;
 	_stepIndex: number;
 	_loop: boolean;
+
+	/**
+	 * Tween の削除可否を表すフラグ。
+	 * isFinished() はアクションが 0 個の場合に真を返さないが、後方互換性のためにこの挙動は変更せず、
+	 * _stale を用いて削除判定を行う。
+	 */
 	_stale: boolean;
 	_modifiedHandler: () => void;
 	_destroyedHandler: () => boolean;
@@ -389,6 +395,10 @@ export class Tween {
 		return ret;
 	}
 
+	/**
+	 * アニメーションが削除可能かどうかを返す。
+	 * 通常、ゲーム開発者がこのメソッドを呼び出す必要はない。
+	 */
 	shouldRemove(): boolean {
 		return this._stale || this.isFinished();
 	}

--- a/src/Tween.ts
+++ b/src/Tween.ts
@@ -33,6 +33,7 @@ export class Tween {
 	_target: any;
 	_stepIndex: number;
 	_loop: boolean;
+	_stale: boolean;
 	_modifiedHandler: () => void;
 	_destroyedHandler: () => boolean;
 
@@ -60,6 +61,7 @@ export class Tween {
 		this._target = target;
 		this._stepIndex = 0;
 		this._loop = !!option && !!option.loop;
+		this._stale = false;
 		this._modifiedHandler = undefined;
 		if (option && option.modified) {
 			this._modifiedHandler = option.modified;
@@ -366,6 +368,7 @@ export class Tween {
 		this._lastStep = undefined;
 		this._pararel = false;
 		this.paused = false;
+		this._stale = true;
 		if (this._modifiedHandler) {
 			this._modifiedHandler.call(this._target);
 		}
@@ -384,6 +387,10 @@ export class Tween {
 			ret = this._stepIndex !== 0 && this._stepIndex >= this._steps.length && !this._loop;
 		}
 		return ret;
+	}
+
+	shouldRemove(): boolean {
+		return this._stale || this.isFinished();
 	}
 
 	/**

--- a/src/__tests__/TimelineSpec.ts
+++ b/src/__tests__/TimelineSpec.ts
@@ -231,4 +231,31 @@ describe("test Timeline", () => {
 		scene.update.fire();
 	});
 
+	it("_handler - Timeline#create in _handler", () => {
+		let isSucceeded = false;
+		const tl = new Timeline(scene);
+		function addAction(): void {
+			const tw2 = tl.create({x: 100, y: 200});
+			tw2.to({x: 200, y: 300}, 0);
+			tw2.call(() => {
+				isSucceeded = true;
+			});
+		}
+		const tw1 = tl.create({x: 100, y: 200});
+		tw1.to({x: 200, y: 300}, 0);
+		tw1.call(() => {
+			addAction();
+		});
+
+		expect(tl._tweensCreateQue.length).toBe(1);
+		expect(tl._tweens.length).toBe(0);
+		tl._handler(); // consume tw1.to
+		expect(tl._tweensCreateQue.length).toBe(0);
+		expect(tl._tweens.length).toBe(1);
+		tl._handler(); // consume tw1.call
+		tl._handler(); // consume tw2.to
+		tl._handler(); // consume tw2.call
+		expect(isSucceeded).toBe(true);
+
+	});
 });

--- a/src/__tests__/TimelineSpec.ts
+++ b/src/__tests__/TimelineSpec.ts
@@ -40,8 +40,11 @@ describe("test Timeline", () => {
 		expect(tl._tweens.length).toBe(0);
 		tl._handler();
 		tl.remove(tw1);
-		expect(tl._tweens.length).toBe(2); // tw1 はアクションが0個なので remove されない
 		expect(tw1.isFinished()).toBe(false);
+		expect(tl._tweens.length).toBe(2);
+		expect(tw1._stale).toBe(true);
+		expect(tw1.shouldRemove()).toBe(true);
+
 		tw1.to({x: 200, y: 300}, 100);
 		tl.remove(tw1);
 		expect(tw1.isFinished()).toBe(true);
@@ -50,11 +53,16 @@ describe("test Timeline", () => {
 		tl._handler();
 		expect(tw1.isFinished()).toBe(true);
 		expect(tl._tweens.length).toBe(1);
+
 		tl.remove(null);
 		expect(tl._tweens.length).toBe(1);
+
 		tl.remove(tw2);
 		expect(tw2.isFinished()).toBe(false);
 		expect(tl._tweens.length).toBe(1);
+		expect(tw2._stale).toBe(true);
+		expect(tw2.shouldRemove()).toBe(true);
+
 		tw2.to({x: 200, y: 300}, 100);
 		tl.remove(tw2);
 		expect(tw2.isFinished()).toBe(true);
@@ -201,6 +209,26 @@ describe("test Timeline", () => {
 		tw2d = true;
 		scene.update.fire();
 		expect(tl._tweens.length).toBe(0);
+	});
+
+	it("_handler - auto remove empty tweens", () => {
+		const tl = new Timeline(scene);
+		const tw1 = tl.create({x: 100, y: 200});
+		tw1.to({x: 200, y: 300}, 100);
+		expect(tl._tweensCreateQue.length).toBe(1);
+		expect(tl._tweens.length).toBe(0);
+		const tw2 = tl.create({x: 300, y: 400});
+		expect(tl._tweensCreateQue.length).toBe(2);
+		expect(tl._tweens.length).toBe(0);
+		scene.update.fire();
+		expect(tl._tweensCreateQue.length).toBe(0);
+		expect(tl._tweens.length).toBe(2);
+
+		tl.remove(tw1);
+		tl.remove(tw2);
+		scene.update.fire();
+		expect(tl._tweens.length).toBe(0);
+		scene.update.fire();
 	});
 
 });

--- a/src/__tests__/TimelineSpec.ts
+++ b/src/__tests__/TimelineSpec.ts
@@ -256,6 +256,5 @@ describe("test Timeline", () => {
 		tl._handler(); // consume tw2.to
 		tl._handler(); // consume tw2.call
 		expect(isSucceeded).toBe(true);
-
 	});
 });


### PR DESCRIPTION
## このpull requestが解決する内容

<!-- Pull Requestの変更内容の概要を書いてください -->
`Tween#call()` の処理中に `timeline.create()` を実行して Tween を生成した場合、 Tween が Timeline キューに正しく追加されない現象を解決します。
具体的には、 `timeline.create()` で生成された Tween のキューへの追加を `_handler` 実行時まで保留します。
併せて、 Tween の削除タイミングも `_handler` 実行時に統合します。
これにより、アクションが1つも登録されていない Tween を即時削除する方法が無くなるため、 `Tween#shouldRemove()` を追加し、これを削除判定に利用するようにします。

## 破壊的な変更を含んでいるか?

- 部分的にあり（ Tween 削除タイミングが即時ではなく hander 実行時に遅延します）

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

